### PR TITLE
Fixed bounce badge animation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include $(THEOS)/makefiles/common.mk
 
 TWEAK_NAME = BlinkBadge
 BlinkBadge_FILES = Tweak.xm
-BlinkBadge_EXTRA_FRAMEWORKS += Cephei CepheiPrefs
+BlinkBadge_EXTRA_FRAMEWORKS += Cephei CepheiPrefs CoreGraphics UIKit
 
 include $(THEOS_MAKE_PATH)/tweak.mk
 

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -103,9 +103,13 @@ static void nz9_prefChanged() {
                       initialSpringVelocity: 0
                       options: UIViewAnimationOptionCurveEaseOut
                       animations: ^{
-                        self.center = CGPointMake(originalCenter.x, originalCenter.y);
+                        self.center = originalCenter;
                       }
-                      completion: nil];
+                      completion: ^(BOOL finished) {
+                        self.center = originalCenter; // called when animation is cancelled and finished
+                      }];
+            } else {
+              self.center = originalCenter; // called when animation is canceclled
             }
           }];
 }


### PR DESCRIPTION
The issue was when animation is cancelled, your center isn't updated to what it originally was, so your new animation (next time animation begins) your start was different (higher up).